### PR TITLE
Check if part touching virtual floor CanCollide

### DIFF
--- a/src/ServerScriptService/GravityController/GravityController/Collider.lua
+++ b/src/ServerScriptService/GravityController/GravityController/Collider.lua
@@ -142,7 +142,7 @@ end
 function ColliderClass:IsGrounded(isJumpCheck)
 	local parts = (isJumpCheck and self.JumpDetector or self.FloorDetector):GetTouchingParts()
 	for _, part in pairs(parts) do
-		if not part:IsDescendantOf(self.Controller.Character) then
+		if not part:IsDescendantOf(self.Controller.Character) and part.CanCollide then
 			return true
 		end
 	end


### PR DESCRIPTION
Greetings, I'm noticing a stutter in my character's flight when they touch a Pickup part which has CanCollide set to false.  With a little tracing I discovered that my character's state is changing from Freefall to Running when they touch the pickup.  I've made this little change locally and it has alleviated the issue.  Recommend to apply this patch upstream as well.

Best Regards,
[FirstVertex](https://devforum.roblox.com/u/firstvertex)