### PR TITLE
Async handling of TouchEnded

### DIFF
--- a/src/ServerScriptService/GravityController/GravityController/Collider.lua
+++ b/src/ServerScriptService/GravityController/GravityController/Collider.lua
@@ -130,6 +130,7 @@ function init(self)
 	end))
 
 	self._maid:Mark(self.FloorDetector.TouchEnded:Connect(function(hit)
+		wait();
 		if self._floorTouchingParts[hit] then
 			self._floorTouchingParts[hit] = nil
 		end
@@ -142,6 +143,7 @@ function init(self)
 	end))
 
 	self._maid:Mark(self.JumpDetector.TouchEnded:Connect(function(hit)
+		wait();
 		if self._jumpTouchingParts[hit] then
 			self._jumpTouchingParts[hit] = nil
 		end


### PR DESCRIPTION
Give this a try, we can delay by a frame the removal from the cache, so there will be momentary overlap as the Character walks between parts/terrain.

[Cache Invalidation is hard](https://www.karlton.org/2017/12/naming-things-hard/)